### PR TITLE
Modify metadata generation scripts to comply with schema v11.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: tests
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: write

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ pre-commit
 sphinx
 sphinx_rtd_theme
 pytest
-nmdc-schema~=11.3.0
+nmdc-schema~=11.4.0
 requests~=2.32.3
 requests-oauthlib~=2.0.0
 linkml-runtime~=1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ linkml-runtime~=1.8.2
 pyyaml~=6.0.2
 tqdm~=4.66.5
 pandas~=2.2.3
-python-dotenv-1.0.1
+python-dotenv==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nmdc-schema~=11.3.0
+nmdc-schema~=11.4.0
 requests~=2.32.3
 requests-oauthlib~=2.0.0
 linkml-runtime~=1.8.2

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -525,7 +525,6 @@ class NMDCMetadataGenerator(ABC):
         nmdc_id = api.mint_nmdc_id(nmdc_type=NmdcTypes.MetabolomicsAnalysis)[0] + ".1"
         # TODO: Update the minting to handle versioning in the future
 
-        # TODO KRH: Add workflow category to the generation of the workflow object when schema is updated
         data_dict = {
             "id": nmdc_id,
             "name": f"{self.workflow_analysis_name} for {raw_data_name}",
@@ -540,6 +539,7 @@ class NMDCMetadataGenerator(ABC):
             "started_at_time": "placeholder",
             "ended_at_time": "placeholder",
             "type": type,
+            "metabolomics_analysis_category": self.workflow_category
         }
 
         if calibration_id is not None:
@@ -759,8 +759,8 @@ class LCMSLipidomicsMetadataGenerator(NMDCMetadataGenerator):
         self.csv_process_data_description = (
             "Lipid annotations as a result of a lipidomics workflow activity."
         )
-        # TODO KRH: Switch to "LC-MS Lipidomics Processed Data" when the type is added to the schema with release of 11.4
-        self.hdf5_process_data_obj_type = "LC-MS Lipidomics Results"
+
+        self.hdf5_process_data_obj_type = "LC-MS Lipidomics Processed Data"
         self.hdf5_process_data_description = "CoreMS hdf5 file representing a lipidomics data file including annotations."
 
     def run(self):
@@ -1124,8 +1124,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
         self.mass_spec_desc = "Generation of mass spectrometry data by GC/MS for the analysis of metabolites."
         self.mass_spec_eluent_intro = "gas_chromatography"
         self.analyte_category = "metabolome"
-        # TODO KRH: Update to new enum value when available
-        self.raw_data_obj_type = None
+        self.raw_data_obj_type = "GC-MS Raw Data"
         self.raw_data_obj_desc = (
             "GC/MS low resolution raw data for metabolomics data acquisition."
         )

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -1138,7 +1138,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             "https://github.com/microbiomedata/metaMS/wdl/metaMS_gcms.wdl"
         )
         self.workflow_version = "3.0.0"
-        self.workflow_category = "gc_ms_metaboloimcs"
+        self.workflow_category = "gc_ms_metabolomics"
 
         # Processed data attributes
         self.processed_data_category = "processed_data"


### PR DESCRIPTION
This MR will close #12 
 
- Modify the `data_object_type` field for the raw GC/MS data to "GC-MS Raw Data" (new permissible value)
- Modify the `data_object_type` field for the processed LC/MS lipidomics data to "LC-MS Lipidomics Processed Data" (new permissible value)
- Add the field `metabolomics_analysis_category` to the `generate_metabolomics_analysis` method, with values for the GC/MS metabolomics of "gc_ms_metabolomics" and for lipids "lc_ms_lipidomics". Note that this new field (metabolomics_analysis_category) is required and previously loaded records have been updated via migration.
- Update the requirements.txt and requirements-dev.txt to use the most up to date schema version and fix a baby typo
- Modify the test github action to also run the tests daily so we will know if things break without our manually running the workflow