### PR TITLE
Bug fixes for GC/MS metabolomics metadata generation

### DIFF
--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -1542,7 +1542,13 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             # Prepare KEGG Compound ID as an alternative identifier
             alt_ids = []
             if not pd.isna(best_hit["Kegg Compound ID"]):
-                alt_ids.append("kegg:" + best_hit["Kegg Compound ID"])
+                # Check for | in Kegg Compound ID and split if necessary
+                if "|" in best_hit["Kegg Compound ID"]:
+                    alt_ids.extend(
+                        ["kegg:" + x.strip() for x in best_hit["Kegg Compound ID"].split("|")]
+                    )
+                else:
+                    alt_ids.append("kegg:" + best_hit["Kegg Compound ID"])
             alt_ids = list(set(alt_ids))
 
             data_dict = {

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -1262,7 +1262,8 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             attribute_value=self.configuration_file_name,
             fields="id",
         )[0]["id"]
-        parameter_data_id = "nmdc:dobj-13-2p2qmv12"
+        # This is the ID for the parameters toml file
+        parameter_data_id = "nmdc:dobj-11-5tax4f20"
         metadata_df["corems_config_file"] = config_do_id
 
         # check if there is an existing calibration_id in the metadata. If not, we need to generate them

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -378,16 +378,25 @@ class NMDCMetadataGenerator(ABC):
             client_secret=CLIENT_SECRET,
         )
         instrument_id = is_client.get_record_by_attribute(
-            attribute_name="name", attribute_value=instrument_name, fields="id"
+            attribute_name="name",
+            attribute_value=instrument_name,
+            fields="id",
+            exact_match=True,
         )[0]["id"]
         if lc_config_name:
             lc_config_id = cs_client.get_record_by_attribute(
-                attribute_name="name", attribute_value=lc_config_name, fields="id"
+                attribute_name="name",
+                attribute_value=lc_config_name,
+                fields="id",
+                exact_match=True,
             )[0]["id"]
         else:
             lc_config_id = ""
         mass_spec_id = cs_client.get_record_by_attribute(
-            attribute_name="name", attribute_value=mass_spec_config_name, fields="id"
+            attribute_name="name",
+            attribute_value=mass_spec_config_name,
+            fields="id",
+            exact_match=True,
         )[0]["id"]
 
         data_dict = {
@@ -1261,6 +1270,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             attribute_name="name",
             attribute_value=self.configuration_file_name,
             fields="id",
+            exact_match=True,
         )[0]["id"]
         # This is the ID for the parameters toml file
         parameter_data_id = "nmdc:dobj-11-5tax4f20"
@@ -1546,7 +1556,10 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
                 # Check for | in Kegg Compound ID and split if necessary
                 if "|" in best_hit["Kegg Compound ID"]:
                     alt_ids.extend(
-                        ["kegg:" + x.strip() for x in best_hit["Kegg Compound ID"].split("|")]
+                        [
+                            "kegg:" + x.strip()
+                            for x in best_hit["Kegg Compound ID"].split("|")
+                        ]
                     )
                 else:
                     alt_ids.append("kegg:" + best_hit["Kegg Compound ID"])

--- a/src/nom_metadata_generation.py
+++ b/src/nom_metadata_generation.py
@@ -225,12 +225,16 @@ class NOMMetadataGenerator(NMDCMetadataGenerator):
         cs_client = CalibrationSearch()
         try:
             calib_do_id = do_client.get_record_by_attribute(
-                attribute_name="md5_checksum", attribute_value=calib_md5, fields="id"
+                attribute_name="md5_checksum",
+                attribute_value=calib_md5,
+                fields="id",
+                exact_match=True,
             )[0]["id"]
             calibration_id = cs_client.get_record_by_attribute(
                 attribute_name="calibration_object",
                 attribute_value=calib_do_id,
                 fields="id",
+                exact_match=True,
             )[0]["id"]
             print(calib_do_id, calibration_id)
         except ValueError as e:


### PR DESCRIPTION
Add handling for multiple KEGG ids for GC/MS Metabolomics processed data
Fixes #23 

Also fixes a hard coded data object id for the parameter data file.  I mistakenly copied in the wrong data id.