### PR TITLE
Dynamically grab the github workflow version

### DIFF
--- a/src/gcms_metab_metadata_generator.py
+++ b/src/gcms_metab_metadata_generator.py
@@ -94,7 +94,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
     workflow_git_url: str = (
         "https://github.com/microbiomedata/metaMS/wdl/metaMS_gcms.wdl"
     )
-    workflow_version: str = "3.0.0"
+    workflow_version: str
     workflow_category: str = "gc_ms_metabolomics"
 
     # Processed data attributes
@@ -109,6 +109,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
         raw_data_url: str,
         process_data_url: str,
         minting_config_creds: str = None,
+        workflow_version: str = None,
         calibration_standard: str = "fames",
         configuration_file_name: str = "emsl_gcms_corems_params.toml",
     ):
@@ -118,6 +119,14 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             raw_data_url=raw_data_url,
             process_data_url=process_data_url,
         )
+        # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
+        self.workflow_version = workflow_version or (
+            self.get_workflow_version(
+                workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion.cfg"
+            )
+            or "3.1.0"
+        )
+
         self.minting_config_creds = minting_config_creds
         # Calibration attributes
         self.calibration_standard = calibration_standard

--- a/src/gcms_metab_metadata_generator.py
+++ b/src/gcms_metab_metadata_generator.py
@@ -120,11 +120,8 @@ class GCMSMetabolomicsMetadataGenerator(NMDCMetadataGenerator):
             process_data_url=process_data_url,
         )
         # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
-        self.workflow_version = workflow_version or (
-            self.get_workflow_version(
-                workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion.cfg"
-            )
-            or "3.1.0"
+        self.workflow_version = workflow_version or self.get_workflow_version(
+            workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion.cfg"
         )
 
         self.minting_config_creds = minting_config_creds

--- a/src/lcms_lipid_metadata_generator.py
+++ b/src/lcms_lipid_metadata_generator.py
@@ -121,11 +121,8 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
             process_data_url=process_data_url,
         )
         # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
-        self.workflow_version = workflow_version or (
-            self.get_workflow_version(
-                workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_lipid.cfg"
-            )
-            or "1.1.0"
+        self.workflow_version = workflow_version or self.get_workflow_version(
+            workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_lipid.cfg"
         )
         self.minting_config_creds = minting_config_creds
 

--- a/src/lcms_lipid_metadata_generator.py
+++ b/src/lcms_lipid_metadata_generator.py
@@ -85,7 +85,7 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
     workflow_git_url: str = (
         "https://github.com/microbiomedata/metaMS/wdl/metaMS_lipidomics.wdl"
     )
-    workflow_version: str = "1.0.0"
+    workflow_version: str
     workflow_category: str = "lc_ms_lipidomics"
 
     # Processed data attributes
@@ -112,6 +112,7 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
         raw_data_url: str,
         process_data_url: str,
         minting_config_creds: str = None,
+        workflow_version: str = None,
     ):
         super().__init__(
             metadata_file=metadata_file,
@@ -119,7 +120,13 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
             raw_data_url=raw_data_url,
             process_data_url=process_data_url,
         )
-
+        # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
+        self.workflow_version = workflow_version or (
+            self.get_workflow_version(
+                workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_lipid.cfg"
+            )
+            or "1.1.0"
+        )
         self.minting_config_creds = minting_config_creds
 
     def rerun(self):

--- a/src/lcms_metab_metadata_generator.py
+++ b/src/lcms_metab_metadata_generator.py
@@ -83,7 +83,7 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
     workflow_git_url: str = (
         "https://github.com/microbiomedata/metaMS/wdl/metaMS_lcms_metabolomics.wdl"
     )
-    workflow_version: str = "1.0.0"
+    workflow_version: str
     workflow_category: str = "lc_ms_metabolomics"
 
     # Processed data attributes
@@ -110,6 +110,7 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
         raw_data_url: str,
         process_data_url: str,
         minting_config_creds: str = None,
+        workflow_version: str = None,
     ):
         super().__init__(
             metadata_file=metadata_file,
@@ -117,7 +118,14 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
             raw_data_url=raw_data_url,
             process_data_url=process_data_url,
         )
-
+        # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
+        self.workflow_version = (
+            workflow_version
+            or self.get_workflow_version(
+                workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_metabolomics.cfg"
+            )
+            or "1.0.0"
+        )
         self.minting_config_creds = minting_config_creds
 
     def rerun(self):

--- a/src/lcms_metab_metadata_generator.py
+++ b/src/lcms_metab_metadata_generator.py
@@ -119,6 +119,7 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
             process_data_url=process_data_url,
         )
         # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
+        # TODO remove default, use correct version
         self.workflow_version = (
             workflow_version
             or self.get_workflow_version(

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -877,14 +877,3 @@ class NMDCMetadataGenerator(ABC):
                 f"Failed to fetch the workflow version from the Git repository {workflow_version_git_url}"
             )
         return None
-
-
-if __name__ == "__main__":
-    # Example usage
-    metadata_generator = NMDCMetadataGenerator(
-        metadata_file="path/to/metadata.csv",
-        database_dump_json_path="path/to/dump.json",
-        raw_data_url="http://example.com/raw/",
-        process_data_url="http://example.com/processed/",
-    )
-    metadata_generator.get_workflow_version()

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -2,7 +2,7 @@
 import logging
 from pathlib import Path
 from datetime import datetime
-from dataclasses import dataclass
+import re
 from typing import List, Dict
 from abc import ABC
 import pandas as pd
@@ -850,3 +850,41 @@ class NMDCMetadataGenerator(ABC):
         biosample_object = nmdc.Biosample(**biosamp_dict)
 
         return biosample_object
+
+    def get_workflow_version(self, workflow_version_git_url: str) -> str:
+        """
+        Get the version of the workflow from the git repository.
+
+        Parameters
+        ----------
+        repo_link : str
+            The URL of the git repository containing the workflow version.
+
+        Returns
+        -------
+        str
+            The version of the workflow.
+        """
+        resp = requests.get(workflow_version_git_url)
+        if resp.status_code == 200:
+            # Regular expression to find the current_version
+            match = re.search(r"current_version\s*=\s*([\d.]+)", resp.text)
+            if match:
+                current_version = match.group(1)
+            return current_version
+        else:
+            logging.warning(
+                f"Failed to fetch the workflow version from the Git repository {workflow_version_git_url}"
+            )
+        return None
+
+
+if __name__ == "__main__":
+    # Example usage
+    metadata_generator = NMDCMetadataGenerator(
+        metadata_file="path/to/metadata.csv",
+        database_dump_json_path="path/to/dump.json",
+        raw_data_url="http://example.com/raw/",
+        process_data_url="http://example.com/processed/",
+    )
+    metadata_generator.get_workflow_version()

--- a/src/nom_metadata_generator.py
+++ b/src/nom_metadata_generator.py
@@ -102,12 +102,8 @@ class NOMMetadataGenerator(NMDCMetadataGenerator):
         )
         self.minting_config_creds = minting_config_creds
         # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
-        self.workflow_version = (
-            workflow_version
-            or self.get_workflow_version(
-                workflow_version_git_url="https://github.com/microbiomedata/enviroMS/blob/master/.bumpversion.cfg"
-            )
-            or "4.3.1"
+        self.workflow_version = workflow_version or self.get_workflow_version(
+            workflow_version_git_url="https://github.com/microbiomedata/enviroMS/blob/master/.bumpversion.cfg"
         )
 
     def rerun(self):

--- a/src/nom_metadata_generator.py
+++ b/src/nom_metadata_generator.py
@@ -83,7 +83,7 @@ class NOMMetadataGenerator(NMDCMetadataGenerator):
     mass_spec_eluent_intro: str = "direct_infusion_autosampler"
     processing_institution: str = "EMSL"
     workflow_git_url: str = "https://github.com/microbiomedata/enviroMS"
-    workflow_version: str = "4.3.1"
+    workflow_version: str
 
     def __init__(
         self,
@@ -92,6 +92,7 @@ class NOMMetadataGenerator(NMDCMetadataGenerator):
         raw_data_url: str,
         process_data_url: str,
         minting_config_creds: str = None,
+        workflow_version: str = None,
     ):
         super().__init__(
             metadata_file=metadata_file,
@@ -100,6 +101,14 @@ class NOMMetadataGenerator(NMDCMetadataGenerator):
             process_data_url=process_data_url,
         )
         self.minting_config_creds = minting_config_creds
+        # Set the workflow version, prioritizing user input, then fetching from the Git URL, and finally using a default.
+        self.workflow_version = (
+            workflow_version
+            or self.get_workflow_version(
+                workflow_version_git_url="https://github.com/microbiomedata/enviroMS/blob/master/.bumpversion.cfg"
+            )
+            or "4.3.1"
+        )
 
     def rerun(self):
         """


### PR DESCRIPTION
Instead of hardcoding the github workflow version, use a get request to dynamically fill the parameter. Default values are provided as well as the functionality for the user to pass in a version in the instance they are intentionally running a previous workflow version. 