### PR TITLE
Add generation of manifest records to workflow metadata generation

### DIFF
--- a/src/data_classes.py
+++ b/src/data_classes.py
@@ -109,7 +109,8 @@ class GCMSMetabWorkflowMetadata:
     raw_data_url : str, optional
         Complete URL for the raw data file. If provided, this takes precedence
         over constructing the URL from base_url + filename.
-
+    manifest_id : str
+        Identifier for the manifest associated with this workflow metadata.
     """
 
     biosample_id: str
@@ -125,6 +126,7 @@ class GCMSMetabWorkflowMetadata:
     execution_resource: float
     calibration_id: str
     raw_data_url: str = None
+    manifest_id: str = None
 
 
 @dataclass
@@ -153,7 +155,8 @@ class LCMSLipidWorkflowMetadata:
     raw_data_url : str, optional
         Complete URL for the raw data file. If provided, this takes precedence
         over constructing the URL from base_url + filename.
-
+    manifest_id : str
+        Identifier for the manifest associated with this workflow metadata.
     """
 
     processed_data_dir: str
@@ -165,3 +168,4 @@ class LCMSLipidWorkflowMetadata:
     instrument_analysis_end_date: str
     execution_resource: float
     raw_data_url: str = None
+    manifest_id: str = None

--- a/src/data_classes.py
+++ b/src/data_classes.py
@@ -49,6 +49,8 @@ class NmdcTypes:
         NMDC type for Chromatography Configuration.
     Instrument : str
         NMDC type for Instrument.
+    Manifest : str
+        NMDC type for Manifest.
 
     """
 
@@ -70,6 +72,7 @@ class NmdcTypes:
     MobilePhaseSegment: str = "nmdc:MobilePhaseSegment"
     ChromatographyConfiguration: str = "nmdc:ChromatographyConfiguration"
     Instrument: str = "nmdc:Instrument"
+    Manifest: str = "nmdc:Manifest"
 
 
 @dataclass

--- a/src/gcms_metab_metadata_generator.py
+++ b/src/gcms_metab_metadata_generator.py
@@ -340,6 +340,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 CLIENT_ID=client_id,
                 CLIENT_SECRET=client_secret,
             )
+        # check if manifest ids are provided or if we need to generate them
         self.check_manifest(
             metadata_df=metadata_df,
             nmdc_database_inst=nmdc_database_inst,

--- a/src/gcms_metab_metadata_generator.py
+++ b/src/gcms_metab_metadata_generator.py
@@ -340,6 +340,12 @@ class GCMSMetabolomicsMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 CLIENT_ID=client_id,
                 CLIENT_SECRET=client_secret,
             )
+        self.check_manifest(
+            metadata_df=metadata_df,
+            nmdc_database_inst=nmdc_database_inst,
+            CLIENT_ID=client_id,
+            CLIENT_SECRET=client_secret,
+        )
 
         # process workflow metadata
         for _, data in tqdm(

--- a/src/gcms_metab_metadata_generator.py
+++ b/src/gcms_metab_metadata_generator.py
@@ -383,6 +383,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 CLIENT_SECRET=client_secret,
                 was_generated_by=mass_spec.id,
                 url=workflow_metadata_obj.raw_data_url,
+                in_manifest=workflow_metadata_obj.manifest_id,
             )
             raw_data_object_id = raw_data_object.id
             # Generate metabolite identifications
@@ -616,6 +617,7 @@ class GCMSMetabolomicsMetadataGenerator(NMDCWorkflowMetadataGenerator):
             execution_resource=row["execution_resource"],
             calibration_id=row["calibration_id"],
             raw_data_url=row.get("raw_data_url"),
+            manifest_id=row.get("manifest_id"),
         )
 
     def generate_metab_identifications(

--- a/src/lcms_metadata_generator.py
+++ b/src/lcms_metadata_generator.py
@@ -87,6 +87,15 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
             CLIENT_ID=client_id,
             CLIENT_SECRET=client_secret,
         )
+
+        # check if manifest ids are provided or if we need to generate them
+        self.check_manifest(
+            metadata_df=metadata_df,
+            nmdc_database_inst=nmdc_database_inst,
+            CLIENT_ID=client_id,
+            CLIENT_SECRET=client_secret,
+        )
+
         # check if the raw data url is directly passed in or needs to be built with raw data file
         raw_col = (
             "raw_data_url" if "raw_data_url" in metadata_df.columns else "raw_data_file"
@@ -126,6 +135,7 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 CLIENT_SECRET=client_secret,
                 was_generated_by=mass_spec.id,
                 url=workflow_metadata.raw_data_url,
+                in_manifest=workflow_metadata.manifest_id,
             )
 
             metab_analysis = self.generate_metabolomics_analysis(
@@ -522,4 +532,5 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
             instrument_analysis_end_date=row["instrument_analysis_end_date"],
             execution_resource=row["execution_resource"],
             raw_data_url=row.get("raw_data_url"),
+            manifest_id=row.get("manifest_id", None),
         )

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -23,6 +23,7 @@ import numpy as np
 import toml
 import requests
 from dotenv import load_dotenv
+import tqdm
 import os
 
 load_dotenv()
@@ -1193,6 +1194,66 @@ class NMDCWorkflowMetadataGenerator(NMDCMetadataGenerator, ABC):
             raise ValueError(
                 f"The following URLs already exist in the database: {', '.join(resp)}"
             )
+
+    def check_manifest(
+        self,
+        metadata_df: pd.DataFrame,
+        nmdc_database_inst: nmdc.Database,
+        CLIENT_ID: str,
+        CLIENT_SECRET: str,
+    ) -> None:
+        """
+        Check if the manifest id is passed in the metadata DataFrame. If not, generate a new manifest id and add it to the NMDC database instance.
+
+        Parameters
+        ----------
+        metadata_df : pd.DataFrame
+            The DataFrame containing the metadata information.
+        nmdc_database_inst : nmdc.Database
+            The NMDC Database instance to add the manifest to if one needs to be generated.
+        CLIENT_ID : str
+            The client ID for the NMDC API. Used to mint a manifest id if one does not exist.
+        CLIENT_SECRET : str
+            The client secret for the NMDC API. Used to mint a manifest id if one does not exist.
+
+        """
+        if (
+            "manifest_id" not in metadata_df.columns
+            or metadata_df["manifest_id"].isnull().all()
+        ):
+            self.generate_manifest(
+                metadata_df=metadata_df,
+                nmdc_database_inst=nmdc_database_inst,
+                CLIENT_ID=CLIENT_ID,
+                CLIENT_SECRET=CLIENT_SECRET,
+            )
+
+    def generate_manifest(
+        self,
+        metadata_df: pd.DataFrame,
+        nmdc_database_inst: nmdc.Database,
+        CLIENT_ID: str,
+        CLIENT_SECRET: str,
+    ) -> None:
+        """
+        Generate manifest information and data objects for each manifest.
+
+        Parameters
+        ----------
+        metadata_df : pd.DataFrame
+            The metadata DataFrame.
+        nmdc_database_inst : nmdc.Database
+            The NMDC Database instance.
+        CLIENT_ID : str
+            The client ID for the NMDC API.
+        CLIENT_SECRET : str
+            The client secret for the NMDC API.
+
+        Returns
+        -------
+        None
+        """
+        pass
 
     def generate_biosample(
         self, biosamp_metadata: dict, CLIENT_ID: str, CLIENT_SECRET: str

--- a/src/metadata_generator.py
+++ b/src/metadata_generator.py
@@ -176,6 +176,7 @@ class NMDCMetadataGenerator:
         CLIENT_SECRET: str,
         was_generated_by: str = None,
         alternative_id: str = None,
+        in_manifest=None,
         url: str = None,
     ) -> nmdc.DataObject:
         """
@@ -241,6 +242,7 @@ class NMDCMetadataGenerator:
             "type": NmdcTypes.DataObject,
             "was_generated_by": was_generated_by,
             "alternative_identifiers": alternative_id,
+            "in_manifest": in_manifest,
         }
 
         # If any of the data_dict values are None or empty strings, remove them

--- a/src/nom_metadata_generator.py
+++ b/src/nom_metadata_generator.py
@@ -163,6 +163,15 @@ class NOMMetadataGenerator(NMDCWorkflowMetadataGenerator):
             CLIENT_ID=client_id,
             CLIENT_SECRET=client_secret,
         )
+
+        # check if manifest ids are provided or if we need to generate them
+        self.check_manifest(
+            metadata_df=metadata_df,
+            nmdc_database_inst=nmdc_database_inst,
+            CLIENT_ID=client_id,
+            CLIENT_SECRET=client_secret,
+        )
+
         # check for duplicate doj urls in the database
         self.check_doj_urls(metadata_df=metadata_df, url_columns=self.unique_columns)
         print(f"ENV: {ENV}")
@@ -204,6 +213,7 @@ class NOMMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 CLIENT_SECRET=client_secret,
                 was_generated_by=mass_spec.id,
                 url=row.get("raw_data_url"),
+                in_manifest=row.get("manifest_id", None),
             )
             # Generate nom analysis instance, workflow_execution_set (metabolomics analysis), uses the raw data zip file
             calibration_id = self.get_calibration_id(


### PR DESCRIPTION
Create the functionality to either a) generate new manifest records and relate them to samples via the in_manifest field OR use an existing manifest record to relate them. 