### PR TITLE
Add ability to pass in data object ids for has_input field in generation process for LCMS Lipidomics and LCMS Metabolomics data

### DIFF
--- a/src/lcms_lipid_metadata_generator.py
+++ b/src/lcms_lipid_metadata_generator.py
@@ -114,6 +114,7 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
         process_data_url: str,
         minting_config_creds: str = None,
         workflow_version: str = None,
+        existing_data_objects: list[str] = [],
     ):
         super().__init__(
             metadata_file=metadata_file,
@@ -126,6 +127,7 @@ class LCMSLipidomicsMetadataGenerator(LCMSMetadataGenerator):
             workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_lipid.cfg"
         )
         self.minting_config_creds = minting_config_creds
+        self.existing_data_objects = existing_data_objects
 
     def rerun(self):
         super().rerun()

--- a/src/lcms_metab_metadata_generator.py
+++ b/src/lcms_metab_metadata_generator.py
@@ -108,6 +108,7 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
         process_data_url: str,
         minting_config_creds: str = None,
         workflow_version: str = None,
+        existing_data_objects: list[str] = [],
     ):
         super().__init__(
             metadata_file=metadata_file,
@@ -120,6 +121,7 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
             workflow_version_git_url="https://github.com/microbiomedata/metaMS/blob/master/.bumpversion_lcmsmetab.cfg"
         )
         self.minting_config_creds = minting_config_creds
+        self.existing_data_objects = existing_data_objects
 
     def rerun(self):
         super().rerun()

--- a/src/lcms_metadata_generator.py
+++ b/src/lcms_metadata_generator.py
@@ -251,7 +251,11 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 raise ValueError(
                     f"Not all processed data objects were created for {workflow_metadata.processed_data_dir}."
                 )
-            has_input = [parameter_data_id, raw_data_object.id]
+            has_input = [
+                parameter_data_id,
+                raw_data_object.id,
+            ] + self.existing_data_objects
+
             self.update_outputs(
                 mass_spec_obj=mass_spec,
                 analysis_obj=metab_analysis,
@@ -470,7 +474,10 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
                 raise ValueError(
                     f"Not all processed data objects were created for {data['processed_data_directory']}."
                 )
-            has_input = [parameter_data_id, raw_data_object_id]
+            has_input = [
+                parameter_data_id,
+                raw_data_object_id,
+            ] + self.existing_data_objects
             self.update_outputs(
                 analysis_obj=metab_analysis,
                 raw_data_obj_id=raw_data_object_id,

--- a/src/tests/test_lcms_lipid_metadata_gen.py
+++ b/src/tests/test_lcms_lipid_metadata_gen.py
@@ -30,6 +30,9 @@ def test_lcms_lipid_metadata_gen():
         database_dump_json_path=output_file,
         raw_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_raw_lcms_lipid/",
         process_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_processed_lcms_lipid/",
+        existing_data_objects=[
+            "nmdc:dobj-11-00095294"
+        ],  # random, existing data object for testing
     )
     # Run the metadata generation process
     generator.run()
@@ -87,6 +90,3 @@ def test_lcms_lipid_biosample_gen():
     file.close()
     # expecting 1 since we only have 1 unique biosample name in the csv
     assert len(working_data["biosample_set"]) == 1
-
-
-test_lcms_lipid_metadata_gen()


### PR DESCRIPTION
Implement an optional parameter to pass in a list of data object ids that will be included in workflow execution set records  `has_input` field