### PR TITLE
Update mechanism to get associated_studies from input samples

### DIFF
--- a/nmdc_ms_metadata_gen/metadata_generator.py
+++ b/nmdc_ms_metadata_gen/metadata_generator.py
@@ -175,9 +175,11 @@ class NMDCMetadataGenerator:
         """
         return nmdc.Database()
 
-    def find_associated_ids(self, ids: list[str]):
+    def find_associated_studies(self, ids: list[str]):
         """
-        Given a list of sample ids, find the associated study ids.
+        Given a list of sample ids, find the associated studies.
+
+        Directly retrieves the associated_studies field from each biosample corresponding to the input sample ids.
 
         Parameters
         ----------
@@ -186,11 +188,52 @@ class NMDCMetadataGenerator:
 
         Returns
         -------
+        dict
+            A dictionary mapping each input sample id to its associated studies.
         """
         search_obj = NMDCSearch(env=ENV)
-        resp = search_obj.get_linked_instances_and_associate_ids(
-            ids=ids, types="nmdc:Study"
+
+        # For processed sample ids, get the biosample ids they are associated with
+        processed_sample_ids = [id for id in ids if "nmdc:procsm" in id]
+        if processed_sample_ids:
+            ps_bio_dict = search_obj.get_linked_instances_and_associate_ids(
+                ids=processed_sample_ids, types="nmdc:Biosample"
+            )
+        else:
+            ps_bio_dict = {}
+
+        # Gather all biosample ids, including those linked from processed sample ids
+        ps_derived_biosamples = [
+            id[0] if isinstance(id, list) else id for id in list(ps_bio_dict.values())
+        ]
+        biosample_ids = [
+            id for id in ids if "nmdc:procsm" not in id
+        ] + ps_derived_biosamples
+
+        # Grab the associated_studies on biosample records
+        biosample_search = BiosampleSearch(env=ENV)
+        biosample_records = biosample_search.get_batch_records(
+            id_list=biosample_ids, search_field="id", fields="id,associated_studies"
         )
+        # Transform into a dictionary keyed by biosample id
+        biosample_records = {record["id"]: record for record in biosample_records}
+
+        # Clean up export so it's a dictionary of original (input) id:associated_studies
+        resp = {}
+        for id in ids:
+            if "nmdc:procsm" in id:
+                bio_id = ps_bio_dict.get(id)
+                if isinstance(bio_id, list):
+                    bio_id = bio_id[0]
+                resp[id] = (
+                    biosample_records.get(bio_id, {}).get("associated_studies")
+                    if bio_id
+                    else None
+                )
+            else:
+                resp[id] = biosample_records.get(id, {}).get("associated_studies")
+
+        # dictionary of sample_id:associated_studies
         return resp
 
     def clean_dict(self, dict: Dict) -> Dict:
@@ -1502,7 +1545,7 @@ class NMDCWorkflowMetadataGenerator(NMDCMetadataGenerator, ABC):
             # make a call to find_associated_ids to get the associated studies
             # build the ID list from the input samples
             sample_ids = metadata_df["sample_id"].unique().tolist()
-            associations = self.find_associated_ids(ids=sample_ids)
+            associations = self.find_associated_studies(ids=sample_ids)
             # map the ids back to the df before returning. associations will be a list of dictionaries with study ids
             for sample_id, studies in associations.items():
                 study_str = str(studies)

--- a/nmdc_ms_metadata_gen/tests/test_stand_alone_generations.py
+++ b/nmdc_ms_metadata_gen/tests/test_stand_alone_generations.py
@@ -345,6 +345,7 @@ def test_get_associated_studies():
     Test getting associated ids from a mix of biosample and processed sample IDs.
     """
 
+    # Gather example input ids
     bs = BiosampleSearch(env=ENV)
     ids = bs.get_records(max_page_size=100, fields="id")
     ps = ProcessedSampleSearch(env=ENV)

--- a/nmdc_ms_metadata_gen/tests/test_stand_alone_generations.py
+++ b/nmdc_ms_metadata_gen/tests/test_stand_alone_generations.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from dotenv import load_dotenv
 from nmdc_api_utilities.biosample_search import BiosampleSearch
+from nmdc_api_utilities.processed_sample_search import ProcessedSampleSearch
 
 from nmdc_ms_metadata_gen.metadata_generator import NMDCMetadataGenerator
 
@@ -339,20 +340,25 @@ def test_json_validate_units_fail():
     assert "'minute' is not one of [" in results["detail"]["configuration_set"][0]
 
 
-def test_get_associated_ids():
+def test_get_associated_studies():
     """
-    Test getting multiple associated ids.
+    Test getting associated ids from a mix of biosample and processed sample IDs.
     """
 
     bs = BiosampleSearch(env=ENV)
-    ids = bs.get_records(max_page_size=500, fields="id")
-    id_list = [x["id"] for x in ids]
+    ids = bs.get_records(max_page_size=100, fields="id")
+    ps = ProcessedSampleSearch(env=ENV)
+    ps_ids = ps.get_records(max_page_size=100, fields="id")
+
+    id_list = [x["id"] for x in ids + ps_ids]
+    assert len(id_list) == 200
 
     gen = NMDCMetadataGenerator()
-    resp = gen.find_associated_ids(ids=id_list)
+    resp = gen.find_associated_studies(ids=id_list)
 
     for id in id_list:
         assert id in resp.keys()
+        assert "nmdc:sty" in resp[id][0]
 
 
 def test_validate_yaml_outline():
@@ -414,11 +420,12 @@ def test_clean_dict_removes_nan():
     assert "none_key" not in result
     assert "empty_key" not in result
 
+
 def test_emsl_study_json_to_nmdc():
     """
     Test the conversion of an EMSL study JSON to NMDC format.
     """
-    
+
     output_file = (
         "tests/test_data/test_database_emsl_study"
         + datetime.now().strftime("%Y%m%d%H%M%S")
@@ -429,7 +436,7 @@ def test_emsl_study_json_to_nmdc():
     emsl_study_json_path = "tests/test_data/test_study_info.json"
     nmdc_json = gen.emsl_study_json_to_nmdc(emsl_study_json_path, output_file)
     validate = gen.validate_nmdc_database(json=nmdc_json, use_api=False)
-    assert validate["result"] == "All Okay!"   
+    assert validate["result"] == "All Okay!"
 
     # Check that the output has the expected structure
     assert "study_set" in nmdc_json
@@ -440,4 +447,3 @@ def test_emsl_study_json_to_nmdc():
         assert "name" in study
         assert "description" in study
         assert "study_category" in study
- 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nmdc_mass_spectrometry_metadata_generation"
-version = "2.6.0"
+version = "2.7.0"
 description = "A Python library for metdata generation for mass spectrometry data as it relates to the NMDC Schema."
 authors = [
     { name = "Olivia Hess", email = "olivia.hess@pnnl.gov" }, { name= "Katherine Heal", email = "katherine.heal@pnnl.gov"}


### PR DESCRIPTION
Closes #229 

Previously we were getting all studies that were available from the linked instances endpoint from an input biosample or processed sample id.  This will instead grab the exact `associated_studies` from the associated biosample (either directly or via its assocaited processed samples).

I also updated the function name to better reflect reality and updated the test to make sure it works the expected way.