### PR TITLE
QC Check for LCMS Lipidomics Workflow

### DIFF
--- a/nmdc_ms_metadata_gen/di_nom_metadata_generator.py
+++ b/nmdc_ms_metadata_gen/di_nom_metadata_generator.py
@@ -1,7 +1,3 @@
-from typing import List
-
-import pandas as pd
-
 from nmdc_ms_metadata_gen.nom_metadata_generator import NOMMetadataGenerator
 
 

--- a/nmdc_ms_metadata_gen/lcms_metab_metadata_generator.py
+++ b/nmdc_ms_metadata_gen/lcms_metab_metadata_generator.py
@@ -73,8 +73,6 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
         Description of HDF5 processed data.
     add_metabolite_ids : bool
         Whether to add metabolite IDs to the metadata.
-    add_wf_stats: bool
-        Whether to add workflow statistics to the metadata.
     """
 
     unique_columns: list[str] = ["processed_data_directory"]
@@ -98,12 +96,6 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
     workflow_version: str
     workflow_category: str = "lc_ms_metabolomics"
     add_metabolite_ids: bool = True
-    add_wf_stats: bool = True
-
-    # QC thresholds
-    peak_count_threshold: int = 0
-    peak_assignment_count_threshold: int = 0
-    c13_isotopologue_count_threshold: int = 0
 
     # Processed data attributes
     wf_config_process_data_category: str = "workflow_parameter_data"
@@ -148,40 +140,6 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
         )
         self.minting_config_creds = minting_config_creds
         self.existing_data_objects = existing_data_objects
-
-    def generate_stats(self, processed_data: pd.DataFrame) -> List[int]:
-        """
-        Generate QC Stats from processed data.
-
-        Parameters
-        ----------
-        processed_data : pd.DataFrame
-            DataFrame containing the processed data.
-
-        Returns
-        -------
-        List[int]
-            List of QC stats generated from the processed data.
-
-        Notes
-        -----
-        This method reads in the processed data file and generates QC stats.
-
-        """
-
-        # Calculate peak_count
-        peak_count = processed_data["Mass Feature ID"].nunique()
-
-        # Calculate peak_assignment_count
-        peak_assignments = processed_data[["Mass Feature ID", "inchikey"]].dropna()
-        peak_assignment_count = peak_assignments["Mass Feature ID"].nunique()
-
-        # Calculate c13_isotopologue_count
-        c13_isotopologue_count = processed_data[
-            "Monoisotopic Mass Feature ID"
-        ].nunique()
-
-        return peak_count, peak_assignment_count, c13_isotopologue_count
 
     def generate_metab_identifications(
         self, processed_data: pd.DataFrame
@@ -244,87 +202,6 @@ class LCMSMetabolomicsMetadataGenerator(LCMSMetadataGenerator):
             metabolite_identifications.append(metabolite_identification)
 
         return metabolite_identifications
-
-    def _get_wf_stats(self, processed_data: pd.DataFrame) -> dict:
-        """Return workflow statistics for metabolomics data as a dict."""
-        peak_count, peak_assignment_count, c13_isotopologue_count = self.generate_stats(
-            processed_data=processed_data
-        )
-        return {
-            "peak_count": peak_count,
-            "peak_assignment_count": peak_assignment_count,
-            "c13_isotopologue_count": c13_isotopologue_count,
-        }
-
-    def _resolve_qc_from_stats(self, qc_status, qc_comment, wf_stats: dict):
-        """Determine qc_status and qc_comment from metabolomics stats and optional CSV input.
-
-        Threshold checks are always run. Resolution follows these rules:
-
-        1. Stats fail AND CSV says "fail": returns "fail" with both the CSV comment and
-           the stat failure message concatenated together.
-        2. Stats fail AND CSV says "pass" or no CSV input: stats prevail, returns "fail"
-           with the stat failure message only.
-        3. Stats pass AND CSV says "fail": CSV override is accepted unconditionally,
-           returns "fail" with the CSV comment only.
-        4. Stats pass AND no CSV "fail": returns "pass" with the CSV comment if provided,
-           otherwise the default pass message.
-
-        Parameters
-        ----------
-        qc_status : str or None
-            QC status value from the CSV, or None if not provided.
-        qc_comment : str or None
-            QC comment value from the CSV, or None if not provided.
-        wf_stats : dict
-            Dictionary of workflow statistics (peak_count, peak_assignment_count,
-            c13_isotopologue_count).
-
-        Returns
-        -------
-        tuple
-            A tuple of (qc_status, qc_comment) resolved according to the rules above.
-        """
-        # Always compute stat failures
-        failed = []
-        if wf_stats.get("peak_count", 0) < self.peak_count_threshold:
-            failed.append(
-                f"peak_count ({wf_stats.get('peak_count', 0)} < {self.peak_count_threshold})"
-            )
-        if (
-            wf_stats.get("peak_assignment_count", 0)
-            < self.peak_assignment_count_threshold
-        ):
-            failed.append(
-                f"peak_assignment_count ({wf_stats.get('peak_assignment_count', 0)} < {self.peak_assignment_count_threshold})"
-            )
-        if (
-            wf_stats.get("c13_isotopologue_count", 0)
-            < self.c13_isotopologue_count_threshold
-        ):
-            failed.append(
-                f"c13_isotopologue_count ({wf_stats.get('c13_isotopologue_count', 0)} < {self.c13_isotopologue_count_threshold})"
-            )
-
-        stat_comment = f"QC failed on: {', '.join(failed)}." if failed else None
-
-        if failed and qc_status == "fail":
-            # Both stats and CSV indicate failure — concatenate comments
-            combined_comment = "; ".join(filter(None, [qc_comment, stat_comment]))
-            return "fail", combined_comment
-        elif failed:
-            # Stats fail, CSV says "pass" or nothing — stats prevail
-            return "fail", stat_comment
-        elif qc_status == "fail":
-            # Stats pass, but CSV explicitly forces a fail — accept it
-            return qc_status, qc_comment
-        else:
-            # Stats pass and no CSV override to fail
-            return "pass", (
-                qc_comment
-                if qc_comment is not None
-                else "QC passed all computed peak count thresholds."
-            )
 
     def rerun(self):
         return super().rerun()

--- a/nmdc_ms_metadata_gen/lcms_metadata_generator.py
+++ b/nmdc_ms_metadata_gen/lcms_metadata_generator.py
@@ -45,6 +45,11 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
         processed sample ID checks even in production mode. Default is False.
     """
 
+    # QC thresholds
+    peak_count_threshold: int = 0
+    peak_assignment_count_threshold: int = 0
+    c13_isotopologue_count_threshold: int = 0
+
     def __init__(
         self,
         metadata_file: str,
@@ -70,13 +75,112 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
         return pd.read_csv(processed_data_file)
 
     def _get_wf_stats(self, processed_data: pd.DataFrame) -> dict:
-        """Hook for subclasses to provide workflow statistics as a dict. Returns {} by default."""
-        return {}
+        """
+        Generate QC Stats from processed data.
+
+        Parameters
+        ----------
+        processed_data : pd.DataFrame
+            DataFrame containing the processed data.
+
+        Returns
+        -------
+        dict
+            Dictionary of QC stats generated from the processed data.
+
+        Notes
+        -----
+        This method reads in the processed data file and generates QC stats.
+
+        """
+
+        # Calculate peak_count
+        peak_count = processed_data["Mass Feature ID"].nunique()
+
+        # Calculate peak_assignment_count
+        peak_assignments = processed_data[["Mass Feature ID", "inchikey"]].dropna()
+        peak_assignment_count = peak_assignments["Mass Feature ID"].nunique()
+
+        # Calculate c13_isotopologue_count
+        c13_isotopologue_count = processed_data[
+            "Monoisotopic Mass Feature ID"
+        ].nunique()
+
+        return {
+            "peak_count": peak_count,
+            "peak_assignment_count": peak_assignment_count,
+            "c13_isotopologue_count": c13_isotopologue_count,
+        }
 
     def _resolve_qc_from_stats(self, qc_status, qc_comment, wf_stats: dict):
-        """Hook for subclasses to determine qc_status/qc_comment from computed stats.
-        By default, returns the values unchanged (i.e. as read from the CSV)."""
-        return qc_status, qc_comment
+        """Determine qc_status and qc_comment from metabolomics stats and optional CSV input.
+
+        Threshold checks are always run. Resolution follows these rules:
+
+        1. Stats fail AND CSV says "fail": returns "fail" with both the CSV comment and
+           the stat failure message concatenated together.
+        2. Stats fail AND CSV says "pass" or no CSV input: stats prevail, returns "fail"
+           with the stat failure message only.
+        3. Stats pass AND CSV says "fail": CSV override is accepted unconditionally,
+           returns "fail" with the CSV comment only.
+        4. Stats pass AND no CSV "fail": returns "pass" with the CSV comment if provided,
+           otherwise the default pass message.
+
+        Parameters
+        ----------
+        qc_status : str or None
+            QC status value from the CSV, or None if not provided.
+        qc_comment : str or None
+            QC comment value from the CSV, or None if not provided.
+        wf_stats : dict
+            Dictionary of workflow statistics (peak_count, peak_assignment_count,
+            c13_isotopologue_count).
+
+        Returns
+        -------
+        tuple
+            A tuple of (qc_status, qc_comment) resolved according to the rules above.
+        """
+        # Always compute stat failures
+        failed = []
+        if wf_stats.get("peak_count", 0) < self.peak_count_threshold:
+            failed.append(
+                f"peak_count ({wf_stats.get('peak_count', 0)} < {self.peak_count_threshold})"
+            )
+        if (
+            wf_stats.get("peak_assignment_count", 0)
+            < self.peak_assignment_count_threshold
+        ):
+            failed.append(
+                f"peak_assignment_count ({wf_stats.get('peak_assignment_count', 0)} < {self.peak_assignment_count_threshold})"
+            )
+        if (
+            wf_stats.get("c13_isotopologue_count", 0)
+            < self.c13_isotopologue_count_threshold
+        ):
+            failed.append(
+                f"c13_isotopologue_count ({wf_stats.get('c13_isotopologue_count', 0)} < {self.c13_isotopologue_count_threshold})"
+            )
+
+        stat_comment = f"QC failed on: {', '.join(failed)}." if failed else None
+
+        if failed and qc_status == "fail":
+            # Both stats and CSV indicate failure — concatenate comments
+            combined_comment = "; ".join(filter(None, [qc_comment, stat_comment]))
+            return "fail", combined_comment
+        elif failed:
+            # Stats fail, CSV says "pass" or nothing — stats prevail
+            return "fail", stat_comment
+        elif qc_status == "fail":
+            # Stats pass, but CSV explicitly forces a fail — accept it
+            return qc_status, qc_comment
+        else:
+            # Stats pass and no CSV override to fail
+            return "pass", (
+                qc_comment
+                if qc_comment is not None
+                else "QC passed all computed peak count thresholds."
+            )
 
     def run(self) -> nmdc.Database:
         """
@@ -188,7 +292,6 @@ class LCMSMetadataGenerator(NMDCWorkflowMetadataGenerator):
             processed_data = self._read_processed_csv(
                 workflow_metadata.processed_data_dir
             )
-            print(processed_data)
 
             # Get workflow stats (subclass-specific) and resolve QC
             wf_stats = self._get_wf_stats(processed_data=processed_data)

--- a/nmdc_ms_metadata_gen/tests/test_lcms_lipid_metadata_gen.py
+++ b/nmdc_ms_metadata_gen/tests/test_lcms_lipid_metadata_gen.py
@@ -52,7 +52,7 @@ def test_lcms_lipid_metadata_gen():
         assert "nmdc:dobj-11-00095294" in record["has_input"]
 
 
-def test_lcms_lipid__processed_sample_metadata_gen():
+def test_lcms_lipid_processed_sample_metadata_gen():
     current_directory = os.path.dirname(__file__)
     csv_file_path = os.path.join(
         current_directory,
@@ -89,12 +89,170 @@ def test_lcms_lipid__processed_sample_metadata_gen():
         assert "nmdc:dobj-11-00095294" in record["has_input"]
 
 
+def test_lcms_lipid_metadata_gen_with_qc_fields_from_csv():
+    """Test LCMS metadata generation with qc_status and qc_comment fields from the CSV.
+    CSV-provided values are accepted as-is when stats also pass (no prefix is added).
+    A CSV "fail" is accepted unconditionally when stats pass.
+    """
+    current_directory = os.path.dirname(__file__)
+    csv_file_path = os.path.join(
+        current_directory, "test_data", "test_metadata_file_lcms_lipid_qc.csv"
+    )
+    # Set up output file with datetime stamp
+    output_file = (
+        "tests/test_data/test_database_lcms_lipid_qc_"
+        + datetime.now().strftime("%Y%m%d%H%M%S")
+        + ".json"
+    )
+    # Start the metadata generation setup
+    generator = LCMSLipidomicsMetadataGenerator(
+        metadata_file=csv_file_path,
+        database_dump_json_path=output_file,
+        raw_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_raw_lcms_lipid/",
+        process_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_processed_lcms_lipid/",
+        test=True,
+    )
+    # Run the metadata generation process
+    metadata = generator.run()
+    validate = generator.validate_nmdc_database(json=metadata, use_api=False)
+    assert validate["result"] == "All Okay!"
+
+    assert os.path.exists(output_file)
+
+    file = open(output_file)
+    working_data = json.load(file)
+    file.close()
+
+    # Should have 2 workflow executions and 2 raw data objects (one per sample)
+    assert len(working_data["workflow_execution_set"]) == 2
+    assert (
+        len(working_data["data_object_set"]) == 5
+    )  # 2 raw + 3 processed for passing sample
+
+    # Check QC status fields
+    qc_pass_count = 0
+    qc_fail_count = 0
+    for record in working_data["workflow_execution_set"]:
+        if "qc_status" in record and record["qc_status"] == "pass":
+            qc_pass_count += 1
+            # For passing QC, should have has_output
+            assert "has_output" in record
+            assert record["has_output"] is not None
+            assert "qc_comment" in record
+            # CSV comment is returned as-is; no prefix is added
+            assert record["qc_comment"] == "Sample passed QC"
+        elif "qc_status" in record and record["qc_status"] == "fail":
+            qc_fail_count += 1
+            # For failing QC, should NOT have has_output
+            assert "has_output" not in record or record["has_output"] is None
+            assert "qc_comment" in record
+            # CSV comment is returned as-is; no prefix is added
+            assert record["qc_comment"] == "Sample failed QC due to low signal"
+
+    assert qc_pass_count == 1
+    assert qc_fail_count == 1
+
+
+def test_lcms_lipid_csv_pass_overridden_by_failing_stats():
+    """Test that a CSV-provided 'pass' is overridden when stats fail the thresholds.
+    Stats always prevail for failures.
+    """
+    current_directory = os.path.dirname(__file__)
+    # Use the QC CSV which has a sample with qc_status="pass"
+    csv_file_path = os.path.join(
+        current_directory, "test_data", "test_metadata_file_lcms_lipid_qc.csv"
+    )
+    output_file = (
+        "tests/test_data/test_database_lcms_lipid_csv_pass_stat_fail_"
+        + datetime.now().strftime("%Y%m%d%H%M%S")
+        + ".json"
+    )
+    generator = LCMSLipidomicsMetadataGenerator(
+        metadata_file=csv_file_path,
+        database_dump_json_path=output_file,
+        raw_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_raw_lcms_lipid/",
+        process_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_processed_lcms_lipid/",
+        test=True,
+    )
+    # Set an impossibly high threshold so stats always fail
+    generator.peak_count_threshold = 999999
+
+    metadata = generator.run()
+    validate = generator.validate_nmdc_database(json=metadata, use_api=False)
+    assert validate["result"] == "All Okay!"
+
+    with open(output_file) as f:
+        working_data = json.load(f)
+
+    # All records should be "fail" regardless of CSV-provided "pass"
+    for record in working_data["workflow_execution_set"]:
+        assert record.get("qc_status") == "fail"
+        assert "peak_count" in record.get("qc_comment", "")
+        assert "< 999999" in record.get("qc_comment", "")
+
+
+def test_lcms_lipid_csv_fail_and_stats_fail_concatenated_comment():
+    """Test that when both CSV provides 'fail' and stats fail, the qc_comment contains
+    both the CSV comment and the stat failure message concatenated together.
+    """
+    current_directory = os.path.dirname(__file__)
+    # Use the QC CSV which has a sample with qc_status="fail" and a qc_comment
+    csv_file_path = os.path.join(
+        current_directory, "test_data", "test_metadata_file_lcms_lipid_qc.csv"
+    )
+    output_file = (
+        "tests/test_data/test_database_lcms_lipid_csv_fail_stat_fail_"
+        + datetime.now().strftime("%Y%m%d%H%M%S")
+        + ".json"
+    )
+    generator = LCMSLipidomicsMetadataGenerator(
+        metadata_file=csv_file_path,
+        database_dump_json_path=output_file,
+        raw_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_raw_lcms_lipid/",
+        process_data_url="https://nmdcdemo.emsl.pnnl.gov/lipidomics/test_data/test_processed_lcms_lipid/",
+        test=True,
+    )
+    # Set an impossibly high threshold so stats always fail
+    generator.peak_count_threshold = 999999
+
+    metadata = generator.run()
+    validate = generator.validate_nmdc_database(json=metadata, use_api=False)
+    assert validate["result"] == "All Okay!"
+
+    with open(output_file) as f:
+        working_data = json.load(f)
+
+    # Find the record that had CSV qc_status="fail"
+    fail_records = [
+        r
+        for r in working_data["workflow_execution_set"]
+        if r.get("qc_status") == "fail"
+    ]
+    assert (
+        len(fail_records) == 2
+    )  # Both samples fail (one from CSV+stats, one from stats only)
+
+    # The record that originally had CSV qc_status="fail" should have a combined comment
+    csv_fail_record = next(
+        (
+            r
+            for r in fail_records
+            if "Sample failed QC due to low signal" in r.get("qc_comment", "")
+        ),
+        None,
+    )
+    assert csv_fail_record is not None, "Expected a record with the CSV fail comment"
+    # Should also contain the stat failure message
+    assert "peak_count" in csv_fail_record["qc_comment"]
+    assert "< 999999" in csv_fail_record["qc_comment"]
+
+
 def test_lcms_lipid_metadata_gen_rerun():
     current_directory = os.path.dirname(__file__)
     csv_file_path = os.path.join(
         current_directory, "test_data", "test_metadata_file_lcms_lipid_rerun.csv"
     )
-    # Set up output file with datetime stame
+    # Set up output file with datetime stamp
     output_file = (
         "tests/test_data/test_database_lcms_lipid_rerun_"
         + datetime.now().strftime("%Y%m%d%H%M%S")

--- a/nmdc_ms_metadata_gen/tests/test_lcms_metab_metadata_gen.py
+++ b/nmdc_ms_metadata_gen/tests/test_lcms_metab_metadata_gen.py
@@ -22,9 +22,9 @@ def test_lcms_metab_metadata_gen():
     csv_file_path = os.path.join(
         current_directory, "test_data", "test_metadata_file_lcms_lipid.csv"
     )
-    # Set up output file with datetime stame
+    # Set up output file with datetime stamp
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_"
+        "tests/test_data/test_database_lcms_metab_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -64,9 +64,9 @@ def test_lcms_metab_metadata_gen_processed_sample():
         "test_data",
         "test_metadata_file_lcms_lipid_processed_sample.csv",
     )
-    # Set up output file with datetime stame
+    # Set up output file with datetime stamp
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_processed_sample_"
+        "tests/test_data/test_database_lcms_metab_processed_sample_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -104,7 +104,7 @@ def test_lcms_metab_metadata_gen_with_qc_fields_from_csv():
     )
     # Set up output file with datetime stamp
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_qc_"
+        "tests/test_data/test_database_lcms_metab_qc_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -173,7 +173,7 @@ def test_lcms_metab_csv_pass_overridden_by_failing_stats():
         current_directory, "test_data", "test_metadata_file_lcms_lipid_qc.csv"
     )
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_csv_pass_stat_fail_"
+        "tests/test_data/test_database_lcms_metab_csv_pass_stat_fail_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -211,7 +211,7 @@ def test_lcms_metab_csv_fail_and_stats_fail_concatenated_comment():
         current_directory, "test_data", "test_metadata_file_lcms_lipid_qc.csv"
     )
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_csv_fail_stat_fail_"
+        "tests/test_data/test_database_lcms_metab_csv_fail_stat_fail_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -262,9 +262,9 @@ def test_lcms_metab_metadata_gen_rerun():
     csv_file_path = os.path.join(
         current_directory, "test_data", "test_metadata_file_lcms_lipid_rerun.csv"
     )
-    # Set up output file with datetime stame
+    # Set up output file with datetime stamp
     output_file = (
-        "tests/test_data/test_database_lcms_lipid_rerun_"
+        "tests/test_data/test_database_lcms_metab_rerun_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -298,7 +298,7 @@ def test_lcms_metab_metadata_gen_with_qc_fields_from_processed_data():
 
     # --- Run 1: default thresholds (=1), all samples should pass ---
     output_file_pass = (
-        "tests/test_data/test_database_lcms_lipid_threshold_pass_"
+        "tests/test_data/test_database_lcms_metab_threshold_pass_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )
@@ -324,7 +324,7 @@ def test_lcms_metab_metadata_gen_with_qc_fields_from_processed_data():
 
     # --- Run 2: impossibly high peak_count_threshold, all samples should fail ---
     output_file_fail = (
-        "tests/test_data/test_database_lcms_lipid_threshold_fail_"
+        "tests/test_data/test_database_lcms_metab_threshold_fail_"
         + datetime.now().strftime("%Y%m%d%H%M%S")
         + ".json"
     )


### PR DESCRIPTION
QC stats and intepretation for LCMS Lipidomics Workflow
- Adjusted LCMS Lipid tests to factor in QC filter pass/fail
- Condensed _generate_wf_stats into _get_wf_stats and moved it up to LCMS generator (since LCMS metabolomics and lipidomics will use same stats)
- GCMS Lipidomics has slightly different column names and doesn't inherit from LCMS generator, so _generate_wf_stats will go on its specific generator. NOM's _generate_wf_stats will stay on its generator (which covers LCMS and diNom)
- removed some unused imports from diNom generator
- updated LCMS metabolomics tests so their outputs were named "metabolomics" instead of "lipidomics" (current setup overwriting each other)