### PR TITLE
use dictionary comprehension to avoid dict mutation error

### DIFF
--- a/nmdc_ms_metadata_gen/metadata_generator.py
+++ b/nmdc_ms_metadata_gen/metadata_generator.py
@@ -720,9 +720,7 @@ class NMDCMetadataGenerator:
             client_secret=CLIENT_SECRET,
         )
 
-        for key, value in data.items():
-            if value is None:
-                data.pop(key)
+        data = {k: v for k, v in data.items() if v is not None}
         data.update(
             {
                 "id": nmdc_id,


### PR DESCRIPTION
This PR changes the `generate_material_processing()` method in `metadata_generator.py` to use dictionary comprehension instead of a for loop with `pop`. This avoids a dictionary mutation error that arises when there are blank values in the supplied YAML.